### PR TITLE
Feature stack traces error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
-github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -106,12 +106,14 @@ github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
modified https://github.com/pkg/errors/blob/5dd12d0cfe7f152f80558d591504ce685299311e/stack.go

I'm not sure how many depth is enough to log, I set depth to 32 follow the github.com/pkg/errors.

#### Trace example
```2025-03-30 11:29:28 | 1b5727cc-f8fe-4f59-bb2d-bc1e16f5e100 | 500 |      817.75µs | 127.0.0.1 | GET | /books | failed to get books
Error: ERROR 
Stack:
github.com/yokeTH/gofiber-template/internal/repository.(*BookRepository).GetBooks
        at /Users/yoketh/Repo/gofiber-template/internal/repository/book.go:43
github.com/yokeTH/gofiber-template/internal/core/service.(*BookService).GetBooks
        at /Users/yoketh/Repo/gofiber-template/internal/core/service/book.go:30
github.com/yokeTH/gofiber-template/internal/handler.(*BookHandler).GetBooks
        at /Users/yoketh/Repo/gofiber-template/internal/handler/book.go:112
github.com/gofiber/fiber/v2.(*App).next
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/router.go:147
github.com/gofiber/fiber/v2.(*Ctx).Next
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/ctx.go:1030
github.com/gofiber/fiber/v2/middleware/healthcheck.New.func1
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/middleware/healthcheck/healthcheck.go:59
github.com/gofiber/fiber/v2.(*Ctx).Next
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/ctx.go:1025
github.com/yokeTH/gofiber-template/internal/server.New.New.func3
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/middleware/recover/recover.go:43
github.com/gofiber/fiber/v2.(*Ctx).Next
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/ctx.go:1025
github.com/gofiber/fiber/v2/middleware/logger.New.func3
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/middleware/logger/logger.go:121
github.com/gofiber/fiber/v2.(*Ctx).Next
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/ctx.go:1025
github.com/yokeTH/gofiber-template/internal/server.New.New.func2
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/middleware/requestid/requestid.go:31
github.com/gofiber/fiber/v2.(*App).next
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/router.go:147
github.com/gofiber/fiber/v2.(*App).handler
        at /Users/yoketh/go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.6/router.go:173
github.com/valyala/fasthttp.(*Server).serveConn
        at /Users/yoketh/go/pkg/mod/github.com/valyala/fasthttp@v1.51.0/server.go:2358
github.com/valyala/fasthttp.(*workerPool).workerFunc
        at /Users/yoketh/go/pkg/mod/github.com/valyala/fasthttp@v1.51.0/workerpool.go:224
github.com/valyala/fasthttp.(*workerPool).getCh.func1
        at /Users/yoketh/go/pkg/mod/github.com/valyala/fasthttp@v1.51.0/workerpool.go:197
runtime.goexit
        at /opt/homebrew/Cellar/go/1.24.0/libexec/src/runtime/asm_arm64.s:1224
```