### PR TITLE
Update Swagger handler to use SwaggerInfo.ReadDoc() instead of file

### DIFF
--- a/pkg/swagger/handler.go
+++ b/pkg/swagger/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/MarceloPetrucio/go-scalar-api-reference"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/adaptor"
+	"github.com/yokeTH/gofiber-template/docs"
 )
 
 type swagger struct {
@@ -19,7 +20,7 @@ func New() *swagger {
 func (s *swagger) Handler() fiber.Handler {
 	return adaptor.HTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		htmlContent, err := scalar.ApiReferenceHTML(&scalar.Options{
-			SpecURL: "./docs/swagger.json",
+			SpecContent: docs.SwaggerInfo.ReadDoc(),
 		})
 
 		if err != nil {


### PR DESCRIPTION
## Fix
```
error parsing URL: parse "file://D:\SE2\condormhub-backend\docs\swagger.json": invalid port ":\SE2\condormhub-backend\docs\swagger.json" after host11:42:02 | 200 | 540.2µs | 127.0.0.1 | GET | /swagger/index.html | -
```

by using generated docs to read openapi instead of this lib